### PR TITLE
Allow network access

### DIFF
--- a/usr.bin.secure-time-sync
+++ b/usr.bin.secure-time-sync
@@ -6,6 +6,10 @@ profile secure-time-sync /usr/{,local/}bin/secure-time-sync flags=(attach_discon
 
   capability sys_time,
 
+  network raw,
+  network inet,
+  network inet6,
+
   owner /dev/tty rw,
 
   owner /etc/ca-certificates/** r,


### PR DESCRIPTION
If no network access, apparmor not work on debian 12, it will be got an audit log `AVC apparmor="DENIED" operation="create" profile="secure-time-sync" pid=833 comm="curl" family="inet" sock_type="dgram" protocol=0 requested_mask="create" denied_mask="create"`.